### PR TITLE
Fix incorrect cast

### DIFF
--- a/Mir/Native/Handle/mir_rc_context_ptr.cs
+++ b/Mir/Native/Handle/mir_rc_context_ptr.cs
@@ -62,9 +62,9 @@ namespace Mir.Native.Handle
                 if (Context.counter != default(UIntPtr))
                 {
                     if (sizeof(UIntPtr) == 8)
-                        Interlocked.Increment(ref *(int*)(Payload + 16));
+                        Interlocked.Increment(ref *(long*)(Payload + 16));
                     else
-                        Interlocked.Increment(ref *(long*)(Payload + 8));
+                        Interlocked.Increment(ref *(int*)(Payload + 8));
                 }
             }
         }


### PR DESCRIPTION
This one is hard to observe when on a little-endian CPU.

`DecreaseCounter` below correctly uses `long` when `sizeof(UIntPtr) == 8`. `IncreaseCounter` doesn't.